### PR TITLE
add HTTPS protection by nginx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+pki/
+easyrsa/
+recordings/
+initdb.sql

--- a/certs.sh
+++ b/certs.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Your external IP.
+IP=140.112.x.x
+
+echo "This script generates self-signed SSL certificate for protecting connection to guacamole by nginx."
+echo "This script can't be run without interaction!"
+echo "Please run its commands line by line."
+exit 1
+
+git clone https://github.com/OpenVPN/easy-rsa.git
+./easy-rsa/easyrsa3/easyrsa init-pki
+# create CA (you’ll be prompted for Common Name. For example, your lab name: "DSR Lab")
+./easy-rsa/easyrsa3/easyrsa build-ca nopass
+
+SERVICE_NAME=lab
+./easy-rsa/easyrsa3/easyrsa gen-req $SERVICE_NAME nopass
+# Remove old one
+#rm ./pki/issued/$SERVICE_NAME.crt
+# Sign with the new profile
+./easy-rsa/easyrsa3/easyrsa --subject-alt-name="IP:$IP" sign-req serverClient $SERVICE_NAME
+
+cat ./pki/issued/$SERVICE_NAME.crt ./pki/ca.crt > ./pki/issued/$SERVICE_NAME-full.crt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,18 @@
 # =========================================
 
 services:
+  # ------------------------------
+  # Protect connection to guacamole by HTTPS using nginx. 
+  # ------------------------------
+  nginx:
+    image: nginx
+    container_name: nginx
+    restart: unless-stopped
+    ports:
+      - 443:443     
+    volumes:
+      - ./pki:/pki
+      - ./nginx.conf:/etc/nginx/nginx.conf
 
   # ------------------------------
   # 資料庫服務 (MariaDB)
@@ -45,9 +57,9 @@ services:
     image: guacamole/guacamole:latest      # Guacamole Web 前端
     container_name: guacamole
     restart: unless-stopped
-    ports:
+    #ports:
       # - 8080:8080                       # 對外提供服務的Port : Guacamole Web Port 代表 http://<host>:8080
-      - 80:8080                           # 對外提供服務的Port : Guacamole Web Port 代表 http://<host>
+      #- 80:8080                           # 對外提供服務的Port : Guacamole Web Port 代表 http://<host>
     environment:
       WEBAPP_CONTEXT: "ROOT" 
       # 與 guacd / DB 連線設定

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,28 @@
+events {
+    worker_connections 4096;
+}
+
+http {
+    client_max_body_size 32m;
+    
+    server {
+        listen 443 ssl default_server;
+        ssl_certificate /pki/issued/lab-full.crt;
+        ssl_certificate_key /pki/private/lab.key;
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+        ssl_ciphers HIGH:!aNULL:!MD5;
+
+        location / {
+            proxy_pass http://guacamole:8080;
+            proxy_set_header   Host $host;
+            proxy_set_header   X-Real-IP $remote_addr;
+            proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+            # The following two lines improve RDP performance over guacamole greatly.
+            proxy_set_header   Upgrade $http_upgrade;
+            proxy_set_header   Connection "upgrade";
+            proxy_buffering    off;
+            proxy_http_version 1.1;
+        }
+    }
+}


### PR DESCRIPTION
使用 nginx 反向代理 guacamole，加入 HTTPS 連線保護。

並提供 certs.sh 產生 self signed SSL 憑證，免除使用一般 SSL 憑證的較繁瑣的申請、維護流程。

瀏覽器信任自簽憑證後，連線時就不會出現警告畫面。

此為參考設計，歡迎修改。